### PR TITLE
chore: ajuste no DELIMITER do script da camada bronze

### DIFF
--- a/scripts/bronze/01_create_and_load_bronze_table.sql
+++ b/scripts/bronze/01_create_and_load_bronze_table.sql
@@ -134,7 +134,7 @@ FROM '/datasets/raw/comprasnet-contratos-anual-contratos-latest.csv'
 WITH ( 
     FORMAT CSV, 
     HEADER TRUE, 
-    DELIMITER ';', 
+    DELIMITER ',', 
     ENCODING 'LATIN1' 
 );
 


### PR DESCRIPTION
Este PR ajusta o delimitador (`DELIMITER`) do script `scripts/bronze/01_create_and_load_bronze_table.sql`.

Alterações incluídas:
- Alteração do `DELIMITER` no comando `COPY` para corresponder ao formato correto do CSV.

Esta alteração garante que a carga inicial da tabela **bronze.contracts** seja realizada corretamente e mantém consistência com os dados originais do CSV.
