### PR TITLE
chore(bronze): renomeia script da camada bronze

### DIFF
--- a/scripts/bronze/01_create_and_load_bronze_contratos_table.sql
+++ b/scripts/bronze/01_create_and_load_bronze_contratos_table.sql
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS bronze.contratos (
     ingestao_usuario VARCHAR DEFAULT CURRENT_USER 
 ); 
     
-COMMENT ON COLUMN bronze.contratos.id IS 'ID do contrato'; 
+COMMENT ON COLUMN bronze.contratos.id IS 'ID do contrato.'; 
 COMMENT ON COLUMN bronze.contratos.receita_despesa IS 'Tipo de contrato (Receita ou Despesa).'; 
 COMMENT ON COLUMN bronze.contratos.numero IS 'Numero do contrato/empenho.'; 
 COMMENT ON COLUMN bronze.contratos.orgao_codigo IS 'Código do órgão contratante.'; 


### PR DESCRIPTION
Este PR renomeia o script da camada bronze.

Alterações incluídas:
- Renomeação do script para `01_create_and_load_bronze_contratos_table.sql`

Esta alteração garante que o nome reflita corretamente a funcionalidade do script e mantenha a consistência do padrão de nomenclatura do projeto.